### PR TITLE
Explicitly set locale on locale-dependent tests

### DIFF
--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -11,6 +11,7 @@ import org.junit.runners.MethodSorters;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
@@ -18,6 +19,10 @@ import static org.junit.Assert.assertTrue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ApacheDataTypeTest {
+    static {
+        Locale.setDefault(Locale.ROOT);
+    }
+
     private final String line = "64.242.88.10 - - [07/Mar/2004:16:45:56 -0800] \"GET /twiki/bin/attach/Main/PostfixCommands HTTP/1.1\" 401 12846";
 
     private GrokCompiler compiler;

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -34,6 +35,10 @@ import static org.junit.Assert.fail;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GrokTest {
+    static {
+        Locale.setDefault(Locale.ROOT);
+    }
+    
     GrokCompiler compiler;
 
     @Before


### PR DESCRIPTION
Date parsing is locale dependent (if no explicit locale has been provided) which is why `ApacheDataTypeTest` and `GrokTest` failed on systems with a default locale other than English.