### PR TITLE
Remove unnecessary indirections

### DIFF
--- a/src/main/java/io/thekraken/grok/api/Converter.java
+++ b/src/main/java/io/thekraken/grok/api/Converter.java
@@ -3,7 +3,6 @@ package io.thekraken.grok.api;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
 
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -44,11 +43,11 @@ public class Converter {
   private static final Splitter SPLITTER = Splitter.on(DELIMITER).limit(3);
 
   private static final Map<String, Type> TYPES =
-      Arrays.asList(Type.values()).stream()
+      Arrays.stream(Type.values())
           .collect(Collectors.toMap(t -> t.name().toLowerCase(), t -> t));
 
   private static final Map<String, Type> TYPE_ALIASES =
-      Arrays.asList(Type.values()).stream()
+      Arrays.stream(Type.values())
         .flatMap(type -> type.aliases.stream().map(alias -> new AbstractMap.SimpleEntry<>(alias, type)))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/src/main/java/io/thekraken/grok/api/Discovery.java
+++ b/src/main/java/io/thekraken/grok/api/Discovery.java
@@ -16,9 +16,7 @@
 package io.thekraken.grok.api;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,11 +56,10 @@ public class Discovery {
 
     List<Grok> groky = new ArrayList<Grok>(groks.values());
     Map<String, Grok> mGrok = new LinkedHashMap<String, Grok>();
-    Collections.sort(groky, new Comparator<Grok>() {
+    groky.sort(new Comparator<Grok>() {
 
       public int compare(Grok g1, Grok g2) {
-        return (this.complexity(g1.getNamedRegex()) < this.complexity(g2.getNamedRegex())) ? 1
-            : 0;
+        return (this.complexity(g1.getNamedRegex()) < this.complexity(g2.getNamedRegex())) ? 1 : 0;
       }
 
       private int complexity(String expandedPattern) {
@@ -113,10 +110,9 @@ public class Discovery {
     compiler.register(gPatterns);
 
     // Compile the pattern
-    Iterator<Entry<String, String>> it = gPatterns.entrySet().iterator();
-    while (it.hasNext()) {
+    for (Entry<String, String> stringStringEntry : gPatterns.entrySet()) {
       @SuppressWarnings("rawtypes")
-      Map.Entry pairs = (Map.Entry) it.next();
+      Entry pairs = (Entry) stringStringEntry;
       String key = pairs.getKey().toString();
 
       // g.patterns.putAll( gPatterns );
@@ -126,7 +122,6 @@ public class Discovery {
         groks.put(key, g);
       } catch (Exception e) {
         // Add logger
-        continue;
       }
 
     }
@@ -136,12 +131,9 @@ public class Discovery {
 
     // while (!done){
     // done = true;
-    Iterator<Entry<String, Grok>> pit = patterns.entrySet().iterator();
-    while (pit.hasNext()) {
-      @SuppressWarnings("rawtypes")
-      Map.Entry pairs = (Map.Entry) pit.next();
-      String key = pairs.getKey().toString();
-      Grok value = (Grok) pairs.getValue();
+    for (Entry<String, Grok> pairs : patterns.entrySet()) {
+      String key = pairs.getKey();
+      Grok value = pairs.getValue();
 
       // We want to search with more complex pattern
       // We avoid word, small number, space....

--- a/src/main/java/io/thekraken/grok/api/GrokCompiler.java
+++ b/src/main/java/io/thekraken/grok/api/GrokCompiler.java
@@ -57,7 +57,7 @@ public class GrokCompiler {
    */
   public void register(Map<String, String> patternDefinitions) {
     Preconditions.checkNotNull(patternDefinitions);
-    patternDefinitions.forEach((name, pattern) -> register(name, pattern));
+    patternDefinitions.forEach(this::register);
   }
 
   public void registerDefaultPatterns() {
@@ -85,7 +85,7 @@ public class GrokCompiler {
             new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))
     ) {
       in.lines()
-        .map(l -> pattern.matcher(l))
+        .map(pattern::matcher)
         .filter(Matcher::matches)
         .forEach(m -> register(m.group(1), m.group(2)));
     }

--- a/src/main/java/io/thekraken/grok/api/GrokUtils.java
+++ b/src/main/java/io/thekraken/grok/api/GrokUtils.java
@@ -43,7 +43,7 @@ public class GrokUtils {
   }
 
   public static Map<String, String> namedGroups(Matcher matcher, Set<String> groupNames) {
-    Map<String, String> namedGroups = new LinkedHashMap<String, String>();
+    Map<String, String> namedGroups = new LinkedHashMap<>();
     for (String groupName : groupNames) {
       String groupValue = matcher.group(groupName);
       namedGroups.put(groupName, groupValue);

--- a/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
+++ b/src/test/java/io/thekraken/grok/api/ApacheDataTypeTest.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 
@@ -37,13 +38,13 @@ public class ApacheDataTypeTest {
         Map<String, Object> map = gm.capture();
 
         Assertions.assertThat(map).doesNotContainKey("Error");
-        Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
-        assertTrue(map.get("timestamp").equals(ts));
-        assertTrue(map.get("response").equals(Integer.valueOf(401)));
-        assertTrue(map.get("ident").equals(Boolean.FALSE));
-        assertTrue(map.get("httpversion").equals(Float.valueOf(1.1f)));
-        assertTrue(map.get("bytes").equals(Long.valueOf(12846)));
-        assertTrue(map.get("verb").equals("GET"));
+        Instant ts = ZonedDateTime.of(2004, 3, 7, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
+        assertEquals(map.get("timestamp"), ts);
+        assertEquals(map.get("response"), 401);
+        assertEquals(map.get("ident"), Boolean.FALSE);
+        assertEquals(map.get("httpversion"), 1.1f);
+        assertEquals(map.get("bytes"), 12846L);
+        assertEquals("GET", map.get("verb"));
 
     }
 
@@ -56,13 +57,13 @@ public class ApacheDataTypeTest {
 
         Assertions.assertThat(map).doesNotContainKey("Error");
 
-        Instant ts = ZonedDateTime.of(2004, 03, 07, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
-        assertTrue(map.get("timestamp").equals(ts));
-        assertTrue(map.get("response").equals(Integer.valueOf(401)));
-        assertTrue(map.get("ident").equals(Boolean.FALSE));
-        assertTrue(map.get("httpversion").equals(Float.valueOf(1.1f)));
-        assertTrue(map.get("bytes").equals(Long.valueOf(12846)));
-        assertTrue(map.get("verb").equals("GET"));
+        Instant ts = ZonedDateTime.of(2004, 3, 7, 16, 45, 56, 0, ZoneOffset.ofHours(-8)).toInstant();
+        assertEquals(map.get("timestamp"), ts);
+        assertEquals(map.get("response"), 401);
+        assertEquals(map.get("ident"), Boolean.FALSE);
+        assertEquals(map.get("httpversion"), 1.1f);
+        assertEquals(map.get("bytes"), 12846L);
+        assertEquals("GET", map.get("verb"));
 
     }
 

--- a/src/test/java/io/thekraken/grok/api/BasicTest.java
+++ b/src/test/java/io/thekraken/grok/api/BasicTest.java
@@ -28,7 +28,7 @@ public class BasicTest {
 
     @Test
     public void test001_compileFailOnInvalidExpression() throws GrokException {
-        List<String> badRegxp = new ArrayList<String>();
+        List<String> badRegxp = new ArrayList<>();
         badRegxp.add("[");
         badRegxp.add("[foo");
         badRegxp.add("?");
@@ -51,7 +51,7 @@ public class BasicTest {
 
     @Test
     public void test002_compileSuccessValidExpression() throws GrokException {
-        List<String> regxp = new ArrayList<String>();
+        List<String> regxp = new ArrayList<>();
         regxp.add("[hello]");
         regxp.add("(test)");
         regxp.add("(?:hello)");
@@ -79,7 +79,6 @@ public class BasicTest {
     @Test
     public void test005_testLoadPatternFromFile() throws IOException, GrokException {
         File temp = File.createTempFile("grok-tmp-pattern", ".tmp");
-        getClass();
         BufferedWriter bw = new BufferedWriter(new FileWriter(temp));
         bw.write("TEST \\d+");
         bw.close();

--- a/src/test/java/io/thekraken/grok/api/CaptureTest.java
+++ b/src/test/java/io/thekraken/grok/api/CaptureTest.java
@@ -30,7 +30,7 @@ public class CaptureTest {
     }
 
     @Test
-    public void test001_captureMathod() throws Exception {
+    public void test001_captureMathod() {
         compiler.register("foo", ".*");
         Grok grok = compiler.compile("%{foo}");
         Match m = grok.match("Hello World");

--- a/src/test/java/io/thekraken/grok/api/GrokListTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokListTest.java
@@ -26,7 +26,7 @@ public class GrokListTest {
 
     @Test
     public void test_001() throws GrokException {
-        List<String> logs = new ArrayList<String>();
+        List<String> logs = new ArrayList<>();
 
         logs.add("178.21.82.201");
         logs.add("11.178.94.216");
@@ -52,7 +52,7 @@ public class GrokListTest {
 
     @Test
     public void test_002() throws GrokException {
-        List<String> logs = new ArrayList<String>();
+        List<String> logs = new ArrayList<>();
 
         logs.add("178.21.82.201");
         logs.add("11.178.94.216");

--- a/src/test/java/io/thekraken/grok/api/GrokTest.java
+++ b/src/test/java/io/thekraken/grok/api/GrokTest.java
@@ -17,7 +17,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -273,7 +272,7 @@ public class GrokTest {
 
         Grok grok = compiler.compile("%{DAY}");
 
-        List<String> days = new ArrayList<String>();
+        List<String> days = new ArrayList<>();
         days.add("Mon");
         days.add("Monday");
         days.add("Tue");
@@ -319,16 +318,15 @@ public class GrokTest {
 
         Grok grok = compiler.compile("%{MONTH}");
 
-        String[] array = {"Jan", "January", "Feb", "February", "Mar", "March", "Apr", "April", "May", "Jun", "June",
+        String[] months = {"Jan", "January", "Feb", "February", "Mar", "March", "Apr", "April", "May", "Jun", "June",
                 "Jul", "July", "Aug", "August", "Sep", "September", "Oct", "October", "Nov",
                 "November", "Dec", "December"};
-        List<String> months = new ArrayList<String>(Arrays.asList(array));
         int i = 0;
         for (String month : months) {
             Match m = grok.match(month);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("MONTH"), months.get(i));
+            assertEquals(map.get("MONTH"), months[i]);
             i++;
         }
     }
@@ -337,7 +335,7 @@ public class GrokTest {
     public void test015_iso8601() throws GrokException {
         Grok grok = compiler.compile("%{TIMESTAMP_ISO8601}");
 
-        String[] array =
+        String[] times =
                 {"2001-01-01T00:00:00",
                         "1974-03-02T04:09:09",
                         "2010-05-03T08:18:18+00:00",
@@ -353,13 +351,12 @@ public class GrokTest {
                         "2001-11-06T20:45:45.123456-0000",
                         "2001-12-07T23:54:54.123456Z"};
 
-        List<String> times = new ArrayList<String>(Arrays.asList(array));
         int i = 0;
         for (String time : times) {
             Match m = grok.match(time);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("TIMESTAMP_ISO8601"), times.get(i));
+            assertEquals(map.get("TIMESTAMP_ISO8601"), times[i]);
             i++;
         }
     }
@@ -368,7 +365,7 @@ public class GrokTest {
     public void test016_uri() throws GrokException {
         Grok grok = compiler.compile("%{URI}");
 
-        String[] array =
+        String[] uris =
                 {
                         "http://www.google.com",
                         "telnet://helloworld",
@@ -397,13 +394,12 @@ public class GrokTest {
                         "http://www.google.com/search?q=CAPTCHA+ssh&start=0&ie=utf-8&oe=utf-8&client=firefox-a&rls=org.mozilla:en-US:official",
                         "svn+ssh://somehost:12345/testing"};
 
-        List<String> uris = new ArrayList<String>(Arrays.asList(array));
         int i = 0;
         for (String uri : uris) {
             Match m = grok.match(uri);
             Map<String, Object> map = m.capture();
             assertNotNull(map);
-            assertEquals(map.get("URI"), uris.get(i));
+            assertEquals(map.get("URI"), uris[i]);
             assertNotNull(map.get("URIPROTO"));
             i++;
         }
@@ -413,14 +409,13 @@ public class GrokTest {
     public void test017_nonMachingList() throws GrokException {
         Grok grok = compiler.compile("%{URI}");
 
-        String[] array =
+        String[] uris =
                 {
                         "http://www.google.com",
                         "telnet://helloworld",
                         "",
                         "svn+ssh://somehost:12345/testing"
                 };
-        List<String> uris = new ArrayList<String>(Arrays.asList(array));
         int i = 0;
         for (String uri : uris) {
             Match m = grok.match(uri);


### PR DESCRIPTION
There were multiple occurrences of unnecessary indirections in the
code (e. g. first converting an array into a list, then accessing
the list's stream instead of using `Arrays.stream()` in the first place).